### PR TITLE
Fix: data_processor.py

### DIFF
--- a/synthpop/processor/data_processor.py
+++ b/synthpop/processor/data_processor.py
@@ -60,7 +60,7 @@ class DataProcessor:
                 if n_unique < 10:
                     encoder = LabelEncoder()
                 elif n_unique < 50:
-                    encoder = OneHotEncoder(sparse=False, drop="first")
+                    encoder = OneHotEncoder(sparse_output=False, drop="first")
                 else:
                     # Frequency encoding
                     value_counts = data[col].value_counts(normalize=True)


### PR DESCRIPTION
Renamed sklearn.OneHotEncoder's `sparse` parameter to `sparse_output` in `processor/data_processor.py`, since it has been renamed in sklearn:1.2 (the latest is 1.9).

Otherwise `_preprocess()` crashes with `OneHotEncoder.__init__() got an unexpected keyword argument 'sparse'`.

This parameter is also used in `metrics/privacy_metrics.py`, but there it is named correctly: `sparse_output`.